### PR TITLE
Return both markdown and Excel paths from sync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         content: [
           {
             type: 'text',
-            text: `Successfully synced ${result.productCount} products to ${result.filePath}`,
+            text: `Successfully synced ${result.productCount} products to ${result.excelPath}`,
           },
         ],
       };

--- a/src/inventory-service.ts
+++ b/src/inventory-service.ts
@@ -24,7 +24,12 @@ export class InventoryService {
     this.markdownExporter = new MarkdownExporter();
   }
 
-  async syncInventory(): Promise<{ success: boolean; productCount: number; filePath: string }> {
+  async syncInventory(): Promise<{
+    success: boolean;
+    productCount: number;
+    excelPath: string;
+    markdownPath: string;
+  }> {
     try {
       const shopifyProducts = await this.shopifyClient.fetchInventory();
       // const etsyProducts = await this.etsyClient.fetchInventory(); // Disabled
@@ -47,7 +52,8 @@ export class InventoryService {
       return {
         success: true,
         productCount: allProducts.length,
-        filePath: markdownPath,
+        excelPath,
+        markdownPath,
       };
     } catch (error) {
       throw new Error(`Inventory sync failed: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/src/llm-agent.ts
+++ b/src/llm-agent.ts
@@ -136,12 +136,12 @@ For ANY inventory questions (counts, analysis, specific products, etc.), always 
       // Nothing there → sync
       if (files.length === 0) {
         console.log('🔄 No files found. Fetching fresh inventory...');
-        const result = await this.inventoryService.syncInventory();
-        await this.ragService.updateInventory(result.filePath); // should be .md
+          const result = await this.inventoryService.syncInventory();
+          await this.ragService.updateInventory(result.markdownPath); // should be .md
 
-        if (!result.filePath.endsWith('.md')) {
-          throw new Error('Expected .md file path for inventory update');
-        }
+          if (!result.markdownPath.endsWith('.md')) {
+            throw new Error('Expected .md file path for inventory update');
+          }
 
         return `Successfully synced ${result.productCount} products and updated search index`;
       }
@@ -157,9 +157,11 @@ For ANY inventory questions (counts, analysis, specific products, etc.), always 
       console.log('🗑️ Cleaning up inventory files (keep latest .md and latest Excel)...');
       for (const f of files) {
         if (!keepSet.has(f.fp)) {
-          try {
-            fs.unlinkSync(f.fp);
-          } catch {}
+            try {
+              fs.unlinkSync(f.fp);
+            } catch {
+              // Ignore deletion errors
+            }
         }
       }
 
@@ -177,7 +179,7 @@ For ANY inventory questions (counts, analysis, specific products, etc.), always 
       // 4) Stale or missing .md → fetch fresh and index
       console.log('🔄 Fetching fresh inventory data...');
       const result = await this.inventoryService.syncInventory(); // produce fresh .md + excel
-      await this.ragService.updateInventory(result.filePath); // index fresh .md
+      await this.ragService.updateInventory(result.markdownPath); // index fresh .md
       return `Successfully synced ${result.productCount} products and updated search index`;
     }
 


### PR DESCRIPTION
## Summary
- Expose both Excel and Markdown file paths from `syncInventory`
- Use the Excel path when reporting sync results and the Markdown path for RAG indexing
- Handle file cleanup errors gracefully

## Testing
- `npm test` *(fails: No tests found)*
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d68d467848321a3bb4a2bf401a62d