### PR TITLE
Add CLI for direct RAG agent interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ This starts a chat interface where you can:
 - Get analysis: "Which products are low in stock?"
 - Check values: "What's my total inventory value?"
 
+### RAG Agent
+Run the semantic search agent directly:
+```bash
+npm run rag
+```
+
+This starts a lightweight interface that only performs product search using the indexed inventory.
+
 ### As MCP Server
 Run with MCP client:
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "agent": "npm run build && node dist/cli.js",
+    "rag": "npm run build && node dist/rag-cli.js",
     "test": "jest",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",

--- a/src/rag-cli.ts
+++ b/src/rag-cli.ts
@@ -1,0 +1,39 @@
+import dotenv from 'dotenv';
+import readline from 'readline';
+import { RAGService } from './rag-service';
+
+dotenv.config();
+
+async function main() {
+  console.log('🧠 RAG Product Search Agent Starting...');
+
+  const rag = new RAGService();
+
+  console.log('✅ RAG agent ready! Ask product search questions.');
+  console.log('Type "exit" to quit.\n');
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const ask = () => {
+    rl.question('You: ', async (input) => {
+      if (input.toLowerCase() === 'exit') {
+        console.log('Goodbye!');
+        rl.close();
+        process.exit(0);
+      }
+
+      console.log('🤖 RAG: Thinking...');
+      const response = await rag.searchProducts(input);
+      console.log(`🤖 RAG: ${response}\n`);
+
+      ask();
+    });
+  };
+
+  ask();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add rag-cli with interactive loop for product search
- expose rag npm script to run RAG agent directly
- document RAG agent usage in README

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`
- `npm run build`
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_689d6ad0fca08321ab5e9884d6eda619